### PR TITLE
Feat proposal updates farcaster notifications

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,3 +23,16 @@ WARPCAST_BASE_URL=
 WARPCAST_API_KEY=
 # The auth token for Warpcast, used for authenticating API requests.
 WARPCAST_AUTH_TOKEN=
+
+
+# ---------- Easscan GraphQL Endpoints ----------
+# Easscan GraphQL endpoint for Ethereum.
+EASSCAN_GRAPHQL_ETHEREUM_ENDPOINT=
+# Easscan GraphQL endpoint for Base.
+EASSCAN_GRAPHQL_BASE_ENDPOINT=
+# Easscan GraphQL endpoint for Optimism.
+EASSCAN_GRAPHQL_OPTIMISM_ENDPOINT=
+
+
+# Proposal Update Attestation Schema ID.
+PROPDATE_SCHEMA_ID=

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:consume": "node dist/index.js queues consume -l 10",
     "dev:invites": "node dist/index.js process invites",
     "dev:process": "node dist/index.js process proposals",
+    "dev:propdates": "node dist/index.js process propdates",
     "dev:tokengen": "node dist/index.js warpcast token",
     "lint": "eslint",
     "prepare": "husky || :",

--- a/src/commands/process/propdates.ts
+++ b/src/commands/process/propdates.ts
@@ -1,0 +1,191 @@
+import { getCache, setCache } from '@/cache'
+import {
+  getFollowerAddresses,
+  getFollowerDAOs,
+  getFollowerFids,
+  getTreasuryDao,
+  getUserFid,
+} from '@/commands'
+import { logger } from '@/logger'
+import { addToQueue } from '@/queue'
+import { getAttestations } from '@/services/builder/get-propdate-attestations'
+import { filter, pipe } from 'remeda'
+import { JsonValue } from 'type-fest'
+
+/**
+ * Processes new proposal updates and sends notifications to relevant followers
+ * @returns A promise that resolves when all updates have been processed
+ * @throws Error if there's an issue fetching or processing updates
+ */
+async function handleProposalsUpdates() {
+  try {
+    logger.info('Fetching new updates...')
+    const { propdates } = await getAttestations()
+    logger.info({ propdates }, 'New updates retrieved.')
+
+    const userFid = await getUserFid()
+    logger.debug({ userFid }, 'User FID retrieved.')
+    const followers = await getFollowerFids(userFid)
+    logger.info({ followerCount: followers.length }, 'Follower FIDs retrieved.')
+    for (const follower of followers) {
+      logger.debug({ follower }, 'Processing follower.')
+      // Retrieve the ethereum addresses associated with the current follower
+      let addresses = await getFollowerAddresses(follower)
+      logger.debug({ follower, addresses }, 'Follower addresses retrieved.')
+
+      addresses = pipe(
+        addresses,
+        filter((address) => /^0x[a-fA-F0-9]{40}$/.test(address)),
+      )
+      logger.debug(
+        { follower, addresses },
+        'Filtered valid Ethereum addresses.',
+      )
+
+      // If no addresses are found, skip to the next follower
+      if (addresses.length === 0) {
+        logger.info(
+          { follower },
+          'No valid addresses found for follower, skipping.',
+        )
+        continue
+      }
+
+      // Retrieve the DAOs associated with the current follower and their addresses
+      const daos = await getFollowerDAOs(follower, addresses)
+      logger.debug(
+        { follower, daos },
+        'DAOs associated with follower retrieved.',
+      )
+
+      // If no DAOs are found, skip to the next follower
+      if (!daos || daos.length <= 0) {
+        logger.info({ follower }, 'No DAOs found for follower, skipping.')
+        continue
+      }
+
+      // Retrieve notified updates from cache
+      const cacheKey = `notified_proposals_updates_${follower.toString()}`
+      logger.debug({ cacheKey }, 'Retrieving notified updates from cache.')
+      let notifiedUpdates = await getCache<string[]>(cacheKey)
+      if (!notifiedUpdates) {
+        logger.info(
+          { follower },
+          'No notified updates found in cache, initializing new set.',
+        )
+        notifiedUpdates = []
+      } else {
+        logger.debug(
+          { follower, notifiedUpdates },
+          'Notified updates retrieved from cache.',
+        )
+      }
+
+      // Convert notifiedUpdates to a Set for efficient lookups
+      const notifiedUpdatesSet = new Set(notifiedUpdates)
+
+      // Loop through each proposal in the filtered propdates array
+      for (const propdate of propdates) {
+        logger.debug(
+          { proposalId: propdate.propId, milestone: propdate.milestoneId },
+          'Processing proposal update for follower.',
+        )
+
+        // get dao and proposal data from dao treasury address
+        const dao = await getTreasuryDao(
+          propdate.chain,
+          propdate.recipient,
+          propdate.propId,
+        )
+        if (dao === null) {
+          // skip if dao or proposal number doesn't exist
+          continue
+        }
+        // If the proposal's DAO ID is not in the list of DAOs for the current follower, skip to the next update
+        if (!daos.includes(dao.id)) {
+          logger.debug(
+            {
+              proposalId: propdate.propId,
+              milestone: propdate.milestoneId,
+              follower,
+            },
+            'Proposal DAO ID not associated with follower, skipping.',
+          )
+          continue
+        }
+
+        // Check if this proposal has already been notified
+        if (
+          notifiedUpdatesSet.has(
+            `${propdate.propId.toString()}-${propdate.milestoneId.toString()}`,
+          )
+        ) {
+          logger.debug(
+            {
+              proposalId: propdate.propId,
+              milestone: propdate.milestoneId,
+              follower,
+            },
+            'Proposal update already notified, skipping.',
+          )
+          continue
+        }
+
+        // Add the proposal to the queue for notifications
+        logger.info(
+          {
+            proposalId: propdate.propId,
+            milestone: propdate.milestoneId,
+            follower,
+          },
+          'Adding proposal update to notification queue.',
+        )
+        await addToQueue({
+          type: 'notification',
+          recipient: follower,
+          propdate: propdate as unknown as JsonValue,
+          dao: dao as unknown as JsonValue,
+        })
+
+        // Mark this update as notified
+        notifiedUpdatesSet.add(
+          `${propdate.propId.toString()}-${propdate.milestoneId.toString()}`,
+        )
+        logger.debug(
+          {
+            proposalId: propdate.propId,
+            milestone: propdate.milestoneId,
+            follower,
+          },
+          'Proposal Update marked as notified.',
+        )
+      }
+
+      // Update the cache with the new set of notified proposals updates
+      logger.debug(
+        { cacheKey, notifiedProposals: Array.from(notifiedUpdatesSet) },
+        'Updating cache with notified proposals.',
+      )
+      await setCache(cacheKey, Array.from(notifiedUpdatesSet))
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error(
+        { message: error.message, stack: error.stack },
+        'Failed to process proposal updates',
+      )
+    } else {
+      logger.error({ error }, 'Unknown error while processing proposal updates')
+    }
+    throw error // Re-throw to allow proper error handling upstream
+  }
+}
+
+/**
+ * Handles notifications for new proposal updates
+ *
+ * This function triggers notifications for proposal updates that are currently active.
+ */
+export async function processUpdates() {
+  await handleProposalsUpdates()
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,16 @@ const envSchema = z.object({
   BUILDER_SUBGRAPH_ZORA_URL: z
     .string()
     .url('BUILDER_SUBGRAPH_ZORA_URL must be a valid URL'),
+  EASSCAN_GRAPHQL_ETHEREUM_ENDPOINT: z
+    .string()
+    .url('EASSCAN_GRAPHQL_ETHEREUM_ENDPOINT must be a valid URL'),
+  EASSCAN_GRAPHQL_OPTIMISM_ENDPOINT: z
+    .string()
+    .url('EASSCAN_GRAPHQL_OPTIMISM_ENDPOINT must be a valid URL'),
+  EASSCAN_GRAPHQL_BASE_ENDPOINT: z
+    .string()
+    .url('EASSCAN_GRAPHQL_BASE_ENDPOINT must be a valid URL'),
+  PROPDATE_SCHEMA_ID: z.string().min(1, 'PROPDATE_SCHEMA_ID is required'),
   NODE_ENV: z.enum(['development', 'production', 'test']),
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import { processProposalsCommand } from '@/commands/process/proposals'
-import { warpcastToken } from '@/commands/warpcast/token'
 import { processInvitesCommand } from '@/commands/process/invites'
+import { processProposalsCommand } from '@/commands/process/proposals'
 import { queueConsumeCommand } from '@/commands/queues/consume'
+import { warpcastToken } from '@/commands/warpcast/token'
 import { Command } from 'commander'
 import packageJson from '../package.json'
+import { processUpdates } from './commands/process/propdates'
 
 // Create a new Command instance for the CLI tool
 const program = new Command()
@@ -24,6 +25,12 @@ processCommand
   .command('proposals')
   .description('Process proposals from API and enqueue tasks')
   .action(processProposalsCommand)
+
+// Register the 'propdates' sub-command under 'process'
+processCommand
+  .command('propdates')
+  .description('Process proposals updates from API and enqueue tasks')
+  .action(processUpdates)
 
 // Register the 'invites' sub-command under 'process'
 processCommand

--- a/src/services/builder/get-dao-for-treasury.ts
+++ b/src/services/builder/get-dao-for-treasury.ts
@@ -1,0 +1,57 @@
+import { chainEndpoints } from '@/services/builder/index'
+import { Chain, UpdateDao } from '@/services/builder/types'
+import { gql, GraphQLClient } from 'graphql-request'
+import { JsonObject } from 'type-fest'
+
+type Data = {
+  daos: UpdateDao[]
+} & JsonObject
+
+interface Result {
+  dao: UpdateDao
+}
+
+export const getDAOForTreasuryAddress = async (
+  chain: Chain,
+  treasuryAddress: string,
+  proposalNumber: number,
+): Promise<Result> => {
+  const query = gql`
+    {
+      daos(
+        first: 1
+        where: { treasuryAddress: "${treasuryAddress.toLowerCase()}" }
+      ) {
+        id
+        name
+        proposals(        
+          first: 1
+          where: { proposalNumber: ${proposalNumber} }
+          ) {
+          title
+        }
+      }
+    }
+  `
+
+  try {
+    const endpoint = chainEndpoints.find(
+      (endPoint) => endPoint.chain.id === chain.id,
+    )
+    console.log(endpoint)
+    if (!endpoint) {
+      throw new Error(`Endpoint not found for chain ID: ${chain.id.toString()}`)
+    }
+    const client = new GraphQLClient(endpoint.endpoint)
+    const response = await client.request<Data>(query)
+    if (response.daos.length === 0) {
+      throw new Error(`No DAO found for treasury address: ${treasuryAddress}`)
+    } else if (response.daos[0].proposals.length === 0) {
+      throw new Error(`Proposal does not exist: ${proposalNumber.toString()}`)
+    }
+    return { dao: response.daos[0] }
+  } catch (error) {
+    console.error('Error fetching DAO id for Dao Treasury:', error)
+    throw error
+  }
+}

--- a/src/services/builder/get-propdate-attestations.ts
+++ b/src/services/builder/get-propdate-attestations.ts
@@ -1,0 +1,114 @@
+import {
+  Attestation,
+  AttestationJsonData,
+  Propdate,
+  PropdateObject,
+} from '@/services/builder/types'
+import { gql, GraphQLClient } from 'graphql-request'
+import { flatMap, pipe } from 'remeda'
+import { attestationsChainsEndpoints } from '.'
+
+interface Data {
+  attestations: Attestation[]
+}
+
+interface Result {
+  propdates: Propdate[]
+}
+//0x9ee9a1bfbf4f8f9b977c6b30600d6131d2a56d0be8100e2238a057ea8b18be7e
+export const getAttestations = async (): Promise<Result> => {
+  try {
+    const propdatesPromises = attestationsChainsEndpoints.map(
+      async ({ chain, endpoint, schemaId }) => {
+        const query = gql`
+        {
+          attestations(
+            where: {
+              schemaId: {
+                equals: "${schemaId}"
+              }
+            }
+          ) {
+            recipient
+            timeCreated
+            decodedDataJson
+          }
+        }
+      `
+
+        const client = new GraphQLClient(endpoint)
+        const response = await client.request<Data>(query)
+        const propdates = response.attestations.map((attestation) => {
+          const propdateObject = convertPropdateJsonToObject(
+            attestation.decodedDataJson,
+          )
+          return {
+            ...propdateObject,
+            recipient: attestation.recipient,
+            timeCreated: attestation.timeCreated,
+            chain,
+          }
+        })
+        return propdates
+      },
+    )
+    const results = await Promise.all(propdatesPromises)
+
+    const propdates = pipe(
+      results,
+      flatMap((propdates) => propdates),
+    )
+
+    console.log(propdates)
+    return { propdates }
+  } catch (error) {
+    console.error('Error fetching active proposals:', error)
+    throw error
+  }
+}
+
+/**
+ * Converts a JSON string into an Propdate object
+ * @param jsonString - The JSON string containing attestation decodedDataJson
+ * @returns An object with propId, replyTo, response, and milestoneId
+ */
+export function convertPropdateJsonToObject(
+  jsonString: string,
+): PropdateObject {
+  try {
+    const parsed = JSON.parse(jsonString) as AttestationJsonData[]
+
+    const result = parsed.reduce(
+      (acc: Partial<PropdateObject>, item: AttestationJsonData) => {
+        const name = item.name
+        const value = item.value.value
+
+        switch (name) {
+          case 'propId':
+            acc.propId = Number(value)
+            break
+          case 'replyTo':
+          case 'response':
+            acc[name] = String(value)
+            break
+          case 'milestoneId':
+            acc[name] = Number(value)
+            break
+        }
+        return acc
+      },
+      {},
+    ) as PropdateObject
+
+    return result
+  } catch (error) {
+    console.error('Error parsing JSON:', error)
+    // Return default Attestation object with empty/zero values
+    return {
+      propId: 0,
+      replyTo: '',
+      response: '',
+      milestoneId: 0,
+    }
+  }
+}

--- a/src/services/builder/index.ts
+++ b/src/services/builder/index.ts
@@ -27,6 +27,12 @@ export const endpoints: Record<number, string> = {
   7777777: env.BUILDER_SUBGRAPH_ZORA_URL,
 }
 
+export const attestationsEndpoints: Record<number, string> = {
+  1: env.EASSCAN_GRAPHQL_ETHEREUM_ENDPOINT,
+  10: env.EASSCAN_GRAPHQL_OPTIMISM_ENDPOINT,
+  8453: env.EASSCAN_GRAPHQL_BASE_ENDPOINT,
+}
+
 export const chainEndpoints = chains.map((chain) => {
   const endpoint: string | undefined = endpoints[chain.id]
   if (!endpoint) {
@@ -37,3 +43,18 @@ export const chainEndpoints = chains.map((chain) => {
     endpoint,
   }
 })
+
+export const attestationsChainsEndpoints = chains
+  .filter((chain) => chain.id != 7777777)
+  .map((chain) => {
+    const endpoint: string | undefined = attestationsEndpoints[chain.id]
+    const schemaId: string | undefined = env.PROPDATE_SCHEMA_ID
+    if (!endpoint) {
+      throw new Error(`Endpoint not found for chain ID: ${chain.id.toString()}`)
+    }
+    return {
+      chain,
+      endpoint,
+      schemaId,
+    }
+  })

--- a/src/services/builder/types.ts
+++ b/src/services/builder/types.ts
@@ -3,6 +3,10 @@ export interface Env {
   BUILDER_SUBGRAPH_BASE_URL: string
   BUILDER_SUBGRAPH_OPTIMISM_URL: string
   BUILDER_SUBGRAPH_ZORA_URL: string
+  EASSCAN_GRAPHQL_ETHEREUM_ENDPOINT: string
+  EASSCAN_GRAPHQL_OPTIMISM_ENDPOINT: string
+  EASSCAN_GRAPHQL_BASE_ENDPOINT: string
+  PROPDATE_SCHEMA_ID: string
 }
 
 export interface Chain {
@@ -33,4 +37,42 @@ export interface Proposal {
   timeCreated: string
   voteStart: string
   voteEnd: string
+}
+
+export interface Attestation {
+  recipient: string
+  decodedDataJson: string
+  timeCreated: number
+}
+
+export interface AttestationJsonData {
+  name: string
+  type: string
+  signature: string
+  value: {
+    name: string
+    type: string
+    value: string | number
+  }
+}
+
+export interface PropdateObject {
+  propId: number
+  replyTo: string
+  response: string
+  milestoneId: number
+}
+
+export interface Propdate extends PropdateObject {
+  chain: Chain
+  recipient: string
+  timeCreated: number
+}
+
+export interface UpdateDao {
+  id: string
+  name: string
+  proposals: {
+    title: string
+  }[]
 }


### PR DESCRIPTION
Add support for processing and notifying proposal updates
Introduces new functionality to:
- Fetch proposal updates via EAS GraphQL endpoints
- Process updates for followers of DAOs
- Send notifications for proposal milestone updates
- Add configuration for EAS GraphQL endpoints and schema ID
- Implement caching mechanism for fetched daos and tracking notified updates